### PR TITLE
Use ansible `file` module for setting executable flag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,5 +8,5 @@
   tags: composer
 
 - name: make composer executable
-  shell: chmod a+x /usr/local/bin/composer
+  file: path=/usr/local/bin/composer mode=a+x state=file
   tags: composer


### PR DESCRIPTION
This will trigger file mode change only when it's needed, instead of setting it every time via `shell` command.